### PR TITLE
Fix linter issues by typing props

### DIFF
--- a/src/components/CatholicCognitiveAtlas.tsx
+++ b/src/components/CatholicCognitiveAtlas.tsx
@@ -14,7 +14,6 @@ export default function CatholicCognitiveAtlas() {
   const [activeBook, setActiveBook] = useState(null);
   const [activeDoctrine, setActiveDoctrine] = useState(null);
   const [timelinePosition, setTimelinePosition] = useState(500); // Default year for timeline
-  const [activeRosaryBead, setActiveRosaryBead] = useState(null);
   const [expandedArtwork, setExpandedArtwork] = useState(null);
 
   // Handle section navigation
@@ -23,7 +22,6 @@ export default function CatholicCognitiveAtlas() {
     // Reset sub-selections when changing main sections to avoid stale state
     setActiveBook(null);
     setActiveDoctrine(null);
-    setActiveRosaryBead(null);
     setExpandedArtwork(null);
   };
 
@@ -55,17 +53,9 @@ export default function CatholicCognitiveAtlas() {
               setPosition={setTimelinePosition}
             />
           )}
-          {activeSection === "liturgy" && (
-            <LiturgicalSystem
-              activeRosaryBead={activeRosaryBead}
-              setActiveRosaryBead={setActiveRosaryBead}
-            />
-          )}
+          {activeSection === "liturgy" && <LiturgicalSystem />}
           {activeSection === "culture" && (
-            <CulturalImpact
-              expandedArtwork={expandedArtwork}
-              setExpandedArtwork={setExpandedArtwork}
-            />
+            <CulturalImpact setExpandedArtwork={setExpandedArtwork} />
           )}
         </div>
       </main>

--- a/src/sections/Bible/BookDetail.tsx
+++ b/src/sections/Bible/BookDetail.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import CommentaryQuote from "../../components/ui/CommentaryQuote";
 import ExpandableSection from "../../components/ui/ExpandableSection";
 import InfoSection from "../../components/ui/InfoSection";
+import type { BookInfo } from "../../types";
 
 interface BookDetailProps {
   book: string;
-  info: any;
+  info: BookInfo | undefined;
   onBack: () => void;
   expandedSection: string | null;
   toggleSection: (section: string) => void;

--- a/src/sections/Culture/ArtworkModal.tsx
+++ b/src/sections/Culture/ArtworkModal.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import type { CulturalItem } from "../../types";
 
 interface ArtworkModalProps {
-  artwork: any;
+  artwork: CulturalItem;
   onClose: () => void;
 }
 

--- a/src/sections/Culture/CulturalImpact.tsx
+++ b/src/sections/Culture/CulturalImpact.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { culturalItems } from "./cultureData";
+import type { CulturalItem } from "../../types";
 
 interface CulturalImpactProps {
-  expandedArtwork: any;
-  setExpandedArtwork: (artwork: any) => void;
+  setExpandedArtwork: (artwork: CulturalItem) => void;
 }
 
-const CulturalImpact: React.FC<CulturalImpactProps> = ({ expandedArtwork, setExpandedArtwork }) => {
+const CulturalImpact: React.FC<CulturalImpactProps> = ({ setExpandedArtwork }) => {
   return (
     <div className="pb-8">
       <h2 className="text-2xl md:text-3xl font-serif mb-6 text-center text-indigo-900">

--- a/src/sections/Liturgy/LiturgicalSystem.tsx
+++ b/src/sections/Liturgy/LiturgicalSystem.tsx
@@ -5,12 +5,7 @@ import ChurchArchitecture from "./ChurchArchitecture";
 import RosaryVisualizer from "./RosaryVisualizer";
 import SacramentalSystem from "./SacramentalSystem";
 
-interface LiturgicalSystemProps {
-  activeRosaryBead: number | null;
-  setActiveRosaryBead: (bead: number | null) => void;
-}
-
-const LiturgicalSystem: React.FC<LiturgicalSystemProps> = ({ activeRosaryBead, setActiveRosaryBead }) => {
+const LiturgicalSystem: React.FC = () => {
   const [activeTab, setActiveTab] = useState("calendar"); // Default to calendar view
 
   return (
@@ -30,12 +25,7 @@ const LiturgicalSystem: React.FC<LiturgicalSystemProps> = ({ activeRosaryBead, s
       {/* Content based on active tab */}
       {activeTab === "calendar" && <LiturgicalCalendar />}
       {activeTab === "architecture" && <ChurchArchitecture />}
-      {activeTab === "rosary" && (
-        <RosaryVisualizer
-          activeRosaryBead={activeRosaryBead}
-          setActiveRosaryBead={setActiveRosaryBead}
-        />
-      )}
+      {activeTab === "rosary" && <RosaryVisualizer />}
       {activeTab === "sacraments" && <SacramentalSystem />}
     </div>
   );

--- a/src/sections/Liturgy/RosaryVisualizer.tsx
+++ b/src/sections/Liturgy/RosaryVisualizer.tsx
@@ -2,12 +2,7 @@ import React, { useState } from "react";
 import RosarySVG from "./RosarySVG";
 import { mysteries } from "./liturgyData";
 
-interface RosaryVisualizerProps {
-  activeRosaryBead: number | null;
-  setActiveRosaryBead: (bead: number | null) => void;
-}
-
-const RosaryVisualizer: React.FC<RosaryVisualizerProps> = ({ activeRosaryBead, setActiveRosaryBead }) => {
+const RosaryVisualizer: React.FC = () => {
   const [selectedMysterySet, setSelectedMysterySet] = useState("joyful");
   const [currentMysteryIndex, setCurrentMysteryIndex] = useState(0);
 

--- a/src/sections/Theology/DoctrineCard.tsx
+++ b/src/sections/Theology/DoctrineCard.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import type { Doctrine } from "../../types";
 
 interface DoctrineCardProps {
-  doctrine: any;
+  doctrine: Doctrine;
   onClick: () => void;
 }
 

--- a/src/sections/Theology/DoctrineDetail.tsx
+++ b/src/sections/Theology/DoctrineDetail.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import InfoSection from "../../components/ui/InfoSection";
 import CommentaryQuote from "../../components/ui/CommentaryQuote";
+import type { Doctrine } from "../../types";
 
 interface DoctrineDetailProps {
-  doctrine: any;
+  doctrine: Doctrine | undefined;
   onBack: () => void;
 }
 

--- a/src/sections/Theology/TheologyTree.tsx
+++ b/src/sections/Theology/TheologyTree.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { nodePositions } from "./theologyData";
+import type { Doctrine } from "../../types";
 
 interface TheologyTreeProps {
-  doctrines: any[];
+  doctrines: Doctrine[];
   setActiveDoctrine: (id: string) => void;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,59 @@
+export interface BookInfo {
+  author: string;
+  date: string;
+  structure: string;
+  themes: string[];
+  commentary: string;
+  theologicalSignificance: string;
+  literaryFeatures: string;
+  keyScenes?: {
+    title: string;
+    reference: string;
+    summary: string;
+    theological: string;
+  }[];
+  typology?: {
+    type: string;
+    explanation: string;
+  }[];
+  iAmStatements?: {
+    statement: string;
+    reference: string;
+  }[];
+  symbolism?: {
+    symbol: string;
+    meaning: string;
+  }[];
+  interpretiveTraditions?: {
+    approach: string;
+    explanation: string;
+  }[];
+}
+
+export interface CulturalItem {
+  id: string;
+  title: string;
+  artist: string;
+  year: string;
+  medium: string;
+  description: string;
+  theologicalThemes: string[];
+  imageUrl: string;
+  details: string;
+}
+
+export interface Doctrine {
+  id: string;
+  name: string;
+  description: string;
+  scriptural: string[];
+  councils: string[];
+  symbols: string[];
+  practice: string;
+  patristic: {
+    father: string;
+    text: string;
+  }[];
+  catechism: string;
+  artwork: string;
+}


### PR DESCRIPTION
## Summary
- clean up unused props and state in `CatholicCognitiveAtlas`
- type book details, cultural items and doctrines with new interfaces
- remove unused props from cultural and liturgical components
- fix `RosaryVisualizer` and `LiturgicalSystem` prop definitions
- add shared `types.ts`

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684bee878a548320a6852dc0f6df6b2c